### PR TITLE
Second batch of player experiences improvements.

### DIFF
--- a/LukeMods.StorageInterest/Config.cs
+++ b/LukeMods.StorageInterest/Config.cs
@@ -23,7 +23,54 @@ namespace LukeMods.StorageInterest
         [Slider("Shortes Rate", 10.0f, 600.0f, DefaultValue = 10.0f)]
         public float MinTime = 10.0f;
 
-        public string[] Containers { get; set; } = new[] { "SmallLocker", "Aquarium", "Locker", "StorageContainer" };
+        // Let the player decide if they want to see a message
+        // hovering the mouse over the container that explain
+        // that the interest is disabled for that type of container
+        // or remove the message completely.
+        [Toggle("See when interest is 'disabled'")]
+        public bool WarnDisabledInterest = false;
+
+        // We can use toggles for the core game storages to simplify.
+        [Toggle("Wall Locker")]
+        public bool SmallLocker = true;
+
+        [Toggle("Locker")]
+        public bool Locker = true;
+
+        [Toggle("Fridge")]
+        public bool Fridge = true;
+
+        [Toggle("Aquarium")]
+        public bool Aquarium = true;
+
+        /**
+         * Known issue:
+         * 
+         * The script check the name of the storages to validate which
+         * storage container should have the interest rate calculated.
+         * The Prawn Suit storage is "Storage", which is the same start
+         * of the Seatruck storage name. Currently, the code check if
+         * the storage name "starts with", so this option will always 
+         * generate interest in both the Prawn Suit and Seatruck when
+         * enabled, even if the Seatruck option is false.
+         */
+        [Toggle("Prawn Suit Container")]
+        public bool Storage= false;
+
+        [Toggle("Seatruck Container")]
+        public bool StorageContainer= true;
+
+        // The list of custom storages created by other mods will
+        // be stored in a string array. This toggle will affects the
+        // entire list. We enable or disable ALL custom storages.
+        [Toggle("Custom (Mods) Storage Types")]
+        public bool CustomModsStorageTypes = false;
+
+        // Provide an example to generate the config.json file so players
+        // can extend the list of storages that have the interest feature.
+        // By adding a valid storage type to the list, it will compute
+        // interest just like the core game storages when enabled.
+        public string[] Containers { get; set; } = new[] { "ModCustomStorageType" };
 
         public Config()
         {
@@ -31,6 +78,28 @@ namespace LukeMods.StorageInterest
             {
                 Instance = this;
             }
+        }
+
+        /**
+         * Get all the storage types allowed to have interest rates.
+         */
+        public string[] GetContainers()
+        {
+            List<string> containers = new List<string>();
+
+            if ((Containers != null) && (Containers.Length >= 1) && CustomModsStorageTypes)
+            {
+                containers.AddRange(Containers);
+            }
+
+            if (SmallLocker) containers.Add("SmallLocker");
+            if (Locker) containers.Add("Locker");
+            if (Fridge) containers.Add("Fridge");
+            if (Aquarium) containers.Add("Aquarium");
+            if (Storage) containers.Add("Storage");
+            if (StorageContainer) containers.Add("StorageContainer");
+
+            return containers.ToArray();
         }
     }
 }

--- a/LukeMods.StorageInterest/Initializer.cs
+++ b/LukeMods.StorageInterest/Initializer.cs
@@ -25,6 +25,5 @@ namespace LukeMods.StorageInterest
             // options GUI, the values will be written in the file as well.
             config = OptionsPanelHandler.Main.RegisterModOptions<Config>();
         }
-
     }
 }


### PR DESCRIPTION
- Adding core game containers as toggles to make it easier to manipulate which one will have interest.
- Adding a method to control the list of enabled containers which will also consider mods/custom containes.
- Adding an example of how to fill the config.json when this mod create the file.
- Adding a method to simplify the verification of storages content, to check if they are full.
- Adding options to control if the player will see or not a message, which is used to warn that the current storage container has interest disabled in the configuration.

- Improved the way we check if the target storage has interest rates enabled.
- Improved the player feedback messages when mouse hovering the containers.
- Improved some readability in the code and added verbose comments to help in the cooperation between developers.

- Known issue: Prawn Suit and Seatruck have similar machine names. By enabling the Prawn Suit and disabling the Seatruck, both will trigger the interest as the string comparison will return as true. This is a legacy issue and is being tracked for future fix. By default, the Prawn Suit toggle is disabled.