### PR TITLE
Fixing a validation that required a toggle to keep the mod goal.

### DIFF
--- a/LukeMods.StorageInterest/Config.cs
+++ b/LukeMods.StorageInterest/Config.cs
@@ -66,6 +66,14 @@ namespace LukeMods.StorageInterest
         [Toggle("Custom (Mods) Storage Types")]
         public bool CustomModsStorageTypes = false;
 
+        // To keep the original intended behavior, this new mechanic will
+        // start disabled and available as an option. This allows the
+        // player to receive the interest by just hovering the cursor over
+        // the container instead of needing to open it. The player must
+        // be close enought for the hovering event to compute.
+        [Toggle("Receive interest on hover")]
+        public bool PayInterestOnCursorHovering = false;
+
         // Provide an example to generate the config.json file so players
         // can extend the list of storages that have the interest feature.
         // By adding a valid storage type to the list, it will compute

--- a/LukeMods.StorageInterest/Patches/StorageContainerPatches.cs
+++ b/LukeMods.StorageInterest/Patches/StorageContainerPatches.cs
@@ -99,7 +99,9 @@ namespace LukeMods.StorageInterest.Patches
                 // This will only happen when the player looks at the
                 // container so we will not generate all items in all
                 // containers automatically, causing an inflation of items.
-                if (!StorageContainerIsFull(__instance) && (timePassed > timeRequired))
+                // This is toggled off by default and the player can change
+                // this in the configuration.
+                if (!StorageContainerIsFull(__instance) && (timePassed > timeRequired) && config.PayInterestOnCursorHovering)
                 {
                     // Pickup the item and start the next calculation.
                     StartInterestRateCalculation(__instance);


### PR DESCRIPTION
- To avoid changes that will be out of the initial scope of this mod, we will use a toggle with the default value to behave as intended. For casual players or ones that want to avoid this mechanic, they can enable this toggle to have a different experience.